### PR TITLE
Initialize vars to suppress error messages

### DIFF
--- a/lib/Device/BlinkyTape/WS2811.pm
+++ b/lib/Device/BlinkyTape/WS2811.pm
@@ -28,6 +28,7 @@ See Device::BlinkyTape for documentation.
 sub send_pixel {
     my $self = shift;
     my ($r, $g, $b) = (shift, shift, shift);
+	$r ||= 0; $g ||= 0; $b ||= 0;
     $r = 254 if ($r == 255); # The 255 means end of led line and applies the colors. Drop that value by one. Blinkyboard.py does this.
     $g = 254 if ($g == 255);
     $b = 254 if ($b == 255);


### PR DESCRIPTION
Occasionally the below error messages are printed. Initializing these vars suppresses them.

`Use of uninitialized value $r in numeric eq (==) at /usr/local/share/perl/5.22.2/Device/BlinkyTape/WS2811.pm line 31.
Use of uninitialized value $g in numeric eq (==) at /usr/local/share/perl/5.22.2/Device/BlinkyTape/WS2811.pm line 32.
Use of uninitialized value $b in numeric eq (==) at /usr/local/share/perl/5.22.2/Device/BlinkyTape/WS2811.pm line 33.
Use of uninitialized value $r in chr at /usr/local/share/perl/5.22.2/Device/BlinkyTape/WS2811.pm line 34.
Use of uninitialized value $g in chr at /usr/local/share/perl/5.22.2/Device/BlinkyTape/WS2811.pm line 36.
Use of uninitialized value $b in chr at /usr/local/share/perl/5.22.2/Device/BlinkyTape/WS2811.pm line 38.`